### PR TITLE
as-tensor and as-array functions

### DIFF
--- a/matlisp.asd
+++ b/matlisp.asd
@@ -58,6 +58,7 @@
 					   (:file "tensor-template" :depends-on ("generator" "numeric-template"))))
 				 (:file "generic" :depends-on (#:template))
 				 (:file "print" :depends-on (#:generic))
+                                 (:file "interop" :depends-on (#:generic))
 				 (:module #:accessor :pathname "" :depends-on (#:template) :components
 					  ((:file "stride-accessor")
 					   (:file "graph-accessor")

--- a/src/base/interop.lisp
+++ b/src/base/interop.lisp
@@ -3,9 +3,8 @@
 
 (in-package #:matlisp)
 
-
 (defgeneric as-tensor (object)
-  (:documentation "Returns OBJECT as a Matlisp tensor type. May share storage."))
+  (:documentation "Returns OBJECT as a Matlisp tensor type. May share storage or copy."))
 
 (defmethod as-tensor ((object tensor))
   "If already a tensor then just return"
@@ -26,7 +25,7 @@
 ;;;
 
 (defgeneric as-array (object)
-  (:documentation "Returns OBJECT as a CL array type. May share storage. "))
+  (:documentation "Returns OBJECT as a CL array type. May share storage or copy. "))
 
 (defmethod as-array ((object array))
   "If already an array, just return"
@@ -35,6 +34,10 @@
 (defmethod as-array ((object tensor))
   "Make an array of the same dimensions as OBJECT, displaced to the storage vector.
    Resulting array shares storage with OBJECT. "
+  ;; If 1D tensor, return the store directly
+  (when (= 1 (length (dimensions object)))
+    (slot-value object 'store))
+  ;; If > 1D, create displaced array
   (with-slots (store dimensions) object
     (make-array (map 'list #'identity dimensions) ; Convert dimensions to list
                 :element-type (array-element-type store)

--- a/src/base/interop.lisp
+++ b/src/base/interop.lisp
@@ -32,14 +32,12 @@
   object)
 
 (defmethod as-array ((object tensor))
-  "Make an array of the same dimensions as OBJECT, displaced to the storage vector.
-   Resulting array shares storage with OBJECT. "
+  "Make an array of the same dimensions as OBJECT. 
+   If 1D, returned array shares storage with OBJECT."
   ;; If 1D tensor, return the store directly
   (when (= 1 (length (dimensions object)))
     (slot-value object 'store))
-  ;; If > 1D, create displaced array
-  (with-slots (store dimensions) object
-    (make-array (map 'list #'identity dimensions) ; Convert dimensions to list
-                :element-type (array-element-type store)
-                :displaced-to store)))
+  ;; If > 1D, copy into array. Note: can't create displaced array
+  ;; since element ordering in tensor is column-major but arrays are row-major
+  (copy object 'array))
 

--- a/src/base/interop.lisp
+++ b/src/base/interop.lisp
@@ -1,0 +1,42 @@
+;;; Interop
+;;; Functions to convert between Matlisp tensors and CL arrays
+
+(in-package #:matlisp)
+
+
+(defgeneric as-tensor (object)
+  (:documentation "Returns OBJECT as a Matlisp tensor type. May share storage."))
+
+(defmethod as-tensor ((object tensor))
+  "If already a tensor then just return"
+  object)
+
+(defmethod as-tensor ((object simple-vector))
+  "Simple vectors can be used as store for a tensor. 
+   The resulting tensor will share storage with the vector."
+  (make-instance (tensor (array-element-type object)) 
+                 :dimensions  (coerce (array-dimensions object) '(simple-array index-type (*)))
+                 :store object))
+
+(defmethod as-tensor ((object array))
+  "Convert array OBJECT to tensor by copying contents"
+  (copy object
+        (tensor (array-element-type object))))
+
+;;;
+
+(defgeneric as-array (object)
+  (:documentation "Returns OBJECT as a CL array type. May share storage. "))
+
+(defmethod as-array ((object array))
+  "If already an array, just return"
+  object)
+
+(defmethod as-array ((object tensor))
+  "Make an array of the same dimensions as OBJECT, displaced to the storage vector.
+   Resulting array shares storage with OBJECT. "
+  (with-slots (store dimensions) object
+    (make-array (map 'list #'identity dimensions) ; Convert dimensions to list
+                :element-type (array-element-type store)
+                :displaced-to store)))
+

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -199,6 +199,8 @@
    #:norm #:psd-proj #:tr #:tensor-max #:tensor-min
    #:ones #:eye! #:eye #:diag #:diaeg~
    #:range #:linspace #:polyfit #:polyval #:roots
+   ;; interop
+   #:as-tensor #:as-array 
    ;; distributions
    #:random-byte-kernel #:random-uniform #:random-pareto
    #:random-exponential #:random-normal #:random-gamma

--- a/t/interop.lisp
+++ b/t/interop.lisp
@@ -1,0 +1,49 @@
+(in-package #:matlisp-tests)
+
+(fiveam:in-suite matlisp-tests:matlisp-tests)
+
+(5am:test as-tensor-test
+  ;; Test simple conversion of 1D vectors
+  (let ((a (as-tensor #(1 2 3))))
+    (is (dimensions a) #(3))
+    (is (= (ref a 1) 2))
+    (is (equal (array-element-type (slot-value a 'store)) t)))
+
+  ;; Tensor to tensor same object
+  (let* ((a (ones '(2 3))) ; a is a tensor
+         (b (as-tensor a)))
+    (is (eq a b))) ; Same object
+
+  ;; Conversion of 2D arrays
+  (let* ((a (make-array '(2 3) :initial-element 2.5 :element-type 'single-float))
+         (b (as-tensor a)))
+    (is (equalp (dimensions b) #(2 3)))
+    (is (< (abs (- (ref b 1 2) 2.5)) 1e-8))
+    (is (equal (array-element-type (slot-value b 'store)) 'single-float)))
+
+  (let ((a (as-tensor #2A((1 2 3)
+                          (4 5 6)))))
+    (is (= (ref a 1 1) 5))))
+
+
+(5am:test as-array-test
+  ;; Array not modified
+  (let ((a #(1 2 3)))
+    (is (eq a (as-array a))))
+
+  ;; 1D tensor
+  (let* ((a (range 0 4))
+         (b (as-array a)))
+    (is (= (length b) 4))
+    (is (= (aref b 1) 1)))
+
+  ;; 2D tensor
+
+  (let* ((a (as-tensor #2A((1 2 3)
+                           (4 5 6))))
+         (b (as-array a)))
+    (is (= (array-rank b) 2))
+    (format t "~a~%" b)
+    (is (= (aref b 1 0) 4))
+    (is (= (aref b 0 2) 3))))
+

--- a/t/interop.lisp
+++ b/t/interop.lisp
@@ -43,7 +43,6 @@
                            (4 5 6))))
          (b (as-array a)))
     (is (= (array-rank b) 2))
-    (format t "~a~%" b)
     (is (= (aref b 1 0) 4))
     (is (= (aref b 0 2) 3))))
 


### PR DESCRIPTION
Adds wrappers around copy and (make-instance tensor...) to convert between Matlisp tensors and CL arrays. Not sure if this is the best way to do this, but it may be more intuitive for a new user (like me).

* 1D arrays and tensors share storage
* Multidimensional arrays and tensors are copied
* When converting multidimensional tensor to array, the result is of element-type T, not specialised.

Includes tests, which pass but are not yet run as part of the test suite.
